### PR TITLE
New foundry

### DIFF
--- a/static/v2/AI/Foundry/AgentTextAnalysis.html
+++ b/static/v2/AI/Foundry/AgentTextAnalysis.html
@@ -2019,6 +2019,12 @@ let animating = false;
 let liveEls = [];
 let liveTimelines = [];
 let calloutEnabled = false;
+let piiSetView = null;   // set by the PII step render; mirrors redact toggle to the audience window
+
+// Audience window: apply the presenter's Redact PII toggle.
+if (window.awPresent && typeof window.awPresent.on === 'function') {
+	window.awPresent.on('piiRedact', v => { if (typeof piiSetView === 'function') piiSetView(v === 'after' ? 'after' : 'before'); });
+}
 
 // ── Callout toggle ────────────────────────
 function syncCalloutBtn() {
@@ -2770,9 +2776,12 @@ function renderPiiStep() {
 		redactLabel.textContent = on ? t('piiRedactBtnOn') : t('piiRedactBtn');
 		line.classList.toggle('is-after', on);
 	}
+	piiSetView = setView;   // expose for presenter→audience mirroring
 	toggle.addEventListener('click', () => {
 		if (toggle.disabled) return;
-		setView(toggle.classList.contains('active') ? 'before' : 'after');
+		const next = toggle.classList.contains('active') ? 'before' : 'after';
+		setView(next);
+		if (window.awPresent && typeof window.awPresent.send === 'function') window.awPresent.send('piiRedact', next);
 	});
 	function enableToggle() {
 		toggle.disabled = false;

--- a/static/v2/AI/Foundry/ModelDeployment.html
+++ b/static/v2/AI/Foundry/ModelDeployment.html
@@ -2851,7 +2851,7 @@ const I18N = {
 		tokenEx3T1: 'art',
 		tokenEx3T2: 'ificial',
 		tokenEx3T3: '\u00a0intelli',
-		tokenEx3T4: 'gence',
+		tokenEx3T4: 'gence',ll
 		tokenEx3Count: '4 tokens',
 		tokenEx4Word: 'GPT',
 		tokenEx4T1: 'G',

--- a/static/v2/AI/Foundry/ModelDeployment.html
+++ b/static/v2/AI/Foundry/ModelDeployment.html
@@ -2851,7 +2851,7 @@ const I18N = {
 		tokenEx3T1: 'art',
 		tokenEx3T2: 'ificial',
 		tokenEx3T3: '\u00a0intelli',
-		tokenEx3T4: 'gence',ll
+		tokenEx3T4: 'gence',
 		tokenEx3Count: '4 tokens',
 		tokenEx4Word: 'GPT',
 		tokenEx4T1: 'G',


### PR DESCRIPTION
This pull request updates the audience window in `AgentTextAnalysis.html` to synchronize the "Redact PII" toggle state between the presenter and audience views. The main changes introduce a mechanism for mirroring the presenter's PII redaction toggle to the audience window, ensuring both views stay in sync.

**Presenter-Audience PII Redaction Synchronization:**

* Exposed the `piiSetView` function to allow the audience window to mirror the presenter's PII redaction toggle state.
* Added event listeners to synchronize the PII redaction state: when the presenter toggles redaction, the audience window updates accordingly, and vice versa, using the `awPresent` event system. [[1]](diffhunk://#diff-775928a8b6c5003481f13f4158eed50de339a2c7ada01b1c0a8b9505afe95986R2022-R2027) [[2]](diffhunk://#diff-775928a8b6c5003481f13f4158eed50de339a2c7ada01b1c0a8b9505afe95986R2779-R2784)