### PR TITLE
add learning path for Copilot Studio

### DIFF
--- a/static/v2/CopilotStudio/index.html
+++ b/static/v2/CopilotStudio/index.html
@@ -182,6 +182,35 @@
 	.foot-credit .credit-link:hover { border-color:#0a66c2; color:#0a66c2; opacity:1; }
 	.foot-meta { opacity:0.92; }
 
+	/* ── OFFICIAL LEARNING PATH CTA ── */
+	.learn-cta { max-width:1180px; margin:1.5rem auto 0; padding:0 1.5rem; }
+	.learn-cta-inner {
+		position:relative; overflow:hidden;
+		display:flex; align-items:center; justify-content:space-between; gap:1.6rem; flex-wrap:wrap;
+		padding:1.9rem 2.2rem; border-radius:20px;
+		background:
+			radial-gradient(circle at 10% 18%, rgba(18,165,165,0.22), transparent 55%),
+			radial-gradient(circle at 90% 82%, rgba(0,120,212,0.22), transparent 55%),
+			var(--theme-body-background);
+		border:1px solid var(--theme-border, rgba(128,128,128,0.28));
+		box-shadow:0 10px 30px rgba(0,60,120,0.18);
+	}
+	.learn-cta-text { display:flex; align-items:center; gap:1.1rem; flex:1 1 30ch; }
+	.learn-cta-badge {
+		flex:none; width:56px; height:56px; border-radius:14px; display:grid; place-items:center; font-size:1.85rem;
+		background:linear-gradient(135deg, var(--cs-teal), var(--cs-blue));
+		box-shadow:0 8px 20px rgba(0,120,212,0.35);
+	}
+	.learn-cta-copy .eyebrow { font-size:0.74rem; font-weight:800; letter-spacing:0.14em; text-transform:uppercase; color:var(--cs-teal); }
+	.learn-cta-copy h3 { margin:0.2rem 0 0.35rem; font-size:1.3rem; font-weight:800; line-height:1.2; }
+	.learn-cta-copy p { margin:0; font-size:0.95rem; opacity:0.85; line-height:1.5; max-width:62ch; }
+	.learn-cta-copy p em { font-style:normal; font-weight:700; color:var(--cs-blue); }
+	.learn-cta .btn-cta { flex:none; font-size:0.98rem; padding:0.72rem 1.5rem; }
+	@media (max-width:640px) {
+		.learn-cta-inner { flex-direction:column; align-items:flex-start; text-align:left; }
+		.learn-cta .btn-cta { align-self:stretch; justify-content:center; }
+	}
+
 	.reveal { opacity:0; transform:translateY(22px); }
 
 	@media (max-width:880px) {
@@ -326,6 +355,21 @@
 			<b>apply it to real scenarios</b>
 		</div>
 	</div>
+
+	<!-- ── OFFICIAL LEARNING PATH ── -->
+	<section class="learn-cta reveal" aria-label="Official Microsoft Learn learning path">
+		<div class="learn-cta-inner">
+			<div class="learn-cta-text">
+				<span class="learn-cta-badge" aria-hidden="true">🎓</span>
+				<div class="learn-cta-copy">
+					<div class="eyebrow">Official · Microsoft Learn</div>
+					<h3>Ready to get hands-on?</h3>
+					<p>Take the free, official Microsoft Learn learning path <em>Create and extend custom copilots with Microsoft Copilot Studio</em> — guided modules, labs, and a knowledge check to turn what you just watched into real skills.</p>
+				</div>
+			</div>
+			<a class="btn-cta" href="https://learn.microsoft.com/en-us/training/paths/create-extend-custom-copilots-microsoft-copilot-studio/" target="_blank" rel="noopener noreferrer">Start the learning path ↗</a>
+		</div>
+	</section>
 
 	<footer class="site-foot">
 		<div class="foot-credit">


### PR DESCRIPTION
This pull request adds a prominent call-to-action (CTA) section to promote the official Microsoft Learn learning path for Copilot Studio. The update introduces both the HTML markup and the necessary CSS styles to ensure the CTA is visually engaging and responsive.

**New "Official Learning Path" CTA section:**

* Added a new section in `index.html` that highlights the official Microsoft Learn learning path, including a badge, descriptive text, and a styled CTA button linking to the course.

**Styling for the CTA:**

* Introduced new CSS rules for `.learn-cta` and related classes to provide a visually distinct, responsive, and accessible design for the learning path CTA.