### PR TITLE
add css

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -143,63 +143,71 @@ table {
 }
 
 /* ============================================================
-   AI Journey shortcut — navbar CTA (→ /v2/AI/Foundry/)
+   Experience switch — iOS-style toggle: classic docs ⟷ new animated journeys
+   Navbar switch is OFF (click loads /v2/); the /v2/ hub switch is ON (click loads /).
    ============================================================ */
-.navbar-ai-journey {
+.exp-switch {
   display: inline-flex !important;
   align-items: center;
-  font-weight: 700;
-  color: #fff !important;
-  padding: 0.35rem 0.9rem !important;
-  margin: 0 0.25rem;
+  gap: 0.5rem;
+  margin: 0 0.5rem;
+  text-decoration: none !important;
+  cursor: pointer;
+}
+
+.exp-switch:hover {
+  text-decoration: none !important;
+}
+
+.exp-switch-track {
+  position: relative;
+  width: 44px;
+  height: 24px;
+  flex: none;
   border-radius: 999px;
-  background: linear-gradient(120deg, #0078d4 0%, #5c2d91 55%, #d24aa8 100%);
-  background-size: 180% 180%;
-  box-shadow: 0 3px 10px rgba(92, 45, 145, 0.35);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
-  animation: aiJourneyGradient 6s ease infinite;
+  background: var(--ifm-color-emphasis-300);
+  transition: background 0.2s ease;
 }
 
-.navbar-ai-journey:hover {
-  color: #fff !important;
-  text-decoration: none;
-  transform: translateY(-1px);
-  box-shadow: 0 6px 16px rgba(92, 45, 145, 0.5);
-  filter: brightness(1.05);
+.exp-switch-knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+  transition: transform 0.2s ease;
 }
 
-.navbar-ai-journey:focus-visible {
-  outline: 3px solid #fff;
-  outline-offset: 2px;
+.exp-switch.is-on .exp-switch-track {
+  background: linear-gradient(120deg, #0078d4 0%, #5c2d91 100%);
 }
 
-/* Animate the emojis inside the navbar label without extra markup */
-@keyframes aiJourneyGradient {
-  0%, 100% { background-position: 0% 50%; }
-  50% { background-position: 100% 50%; }
+.exp-switch.is-on .exp-switch-knob {
+  transform: translateX(20px);
 }
 
-@keyframes aiJourneyPulse {
-  0%, 100% { transform: translateY(-1px) scale(1); }
-  50% { transform: translateY(-1px) scale(1.05); }
+.exp-switch-label {
+  font-size: 0.86rem;
+  font-weight: 600;
+  white-space: nowrap;
+  color: var(--ifm-navbar-link-color);
 }
 
-.navbar-ai-journey:hover {
-  animation: aiJourneyGradient 6s ease infinite, aiJourneyPulse 1.2s ease-in-out infinite;
+.exp-switch:hover .exp-switch-track {
+  filter: brightness(1.06);
 }
 
-/* Stack/condense on smaller screens so it still fits the bar */
+.exp-switch:focus-visible {
+  outline: 3px solid var(--ifm-color-primary);
+  outline-offset: 3px;
+  border-radius: 999px;
+}
+
 @media (max-width: 996px) {
-  .navbar-ai-journey {
-    margin: 0.25rem 0;
-  }
-}
-
-/* Respect reduced-motion preference */
-@media (prefers-reduced-motion: reduce) {
-  .navbar-ai-journey,
-  .navbar-ai-journey:hover {
-    animation: none;
-    transform: none;
+  .exp-switch {
+    margin: 0.5rem 0;
   }
 }

--- a/src/theme/Root.module.css
+++ b/src/theme/Root.module.css
@@ -1,0 +1,150 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  background: rgba(12, 14, 24, 0.55);
+  backdrop-filter: saturate(140%) blur(4px);
+  -webkit-backdrop-filter: saturate(140%) blur(4px);
+  animation: awFade 0.25s ease both;
+}
+
+.card {
+  position: relative;
+  width: min(520px, 100%);
+  background: var(--ifm-background-surface-color, #fff);
+  color: var(--ifm-font-color-base, #1c1e21);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 18px;
+  padding: 2.1rem 1.9rem 1.6rem;
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.35);
+  text-align: center;
+  animation: awPop 0.3s cubic-bezier(0.2, 0.9, 0.3, 1.2) both;
+}
+
+.close {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.7rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--ifm-color-emphasis-600);
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.close:hover {
+  background: var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-emphasis-900);
+}
+
+.badge {
+  display: inline-block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #fff;
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  background: linear-gradient(120deg, #0078d4, #5c2d91 60%, #d24aa8);
+  margin-bottom: 0.9rem;
+}
+
+.title {
+  font-size: 1.5rem;
+  font-weight: 800;
+  margin: 0 0 0.5rem;
+}
+
+.text {
+  font-size: 1rem;
+  color: var(--ifm-color-emphasis-700);
+  margin: 0 0 1.4rem;
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.8rem 1.2rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  background: linear-gradient(120deg, #0078d4 0%, #5c2d91 55%, #d24aa8 100%);
+  box-shadow: 0 8px 22px rgba(92, 45, 145, 0.4);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+}
+
+.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 28px rgba(92, 45, 145, 0.5);
+  filter: brightness(1.05);
+}
+
+.secondary {
+  padding: 0.7rem 1.2rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+  background: transparent;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.secondary:hover {
+  background: var(--ifm-color-emphasis-100);
+  border-color: var(--ifm-color-primary);
+}
+
+.hint {
+  margin: 1rem 0 0;
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-500);
+}
+
+@keyframes awFade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes awPop {
+  from {
+    opacity: 0;
+    transform: translateY(14px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .backdrop,
+  .card {
+    animation: none;
+  }
+}

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -1,0 +1,115 @@
+import React, {useEffect, useRef, useState} from 'react';
+import {useLocation} from '@docusaurus/router';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import styles from './Root.module.css';
+
+// Homepage-only overlay: let visitors pick the new interactive v2 experience or
+// stay on the classic docs site. If they don't choose, it auto-redirects to v2.
+const AUTO_REDIRECT_SECONDS = 10;
+const CHOICE_KEY = 'aw-site-choice';
+
+function ChooseExperience({onClose}: {onClose: () => void}) {
+  const newSiteUrl = useBaseUrl('/v2/index.html');
+  const [secs, setSecs] = useState(AUTO_REDIRECT_SECONDS);
+  const dismissed = useRef(false);
+
+  // `remember` = true persists the "classic" choice so the overlay never nags again.
+  function close(remember: boolean) {
+    dismissed.current = true;
+    if (remember) {
+      try {
+        localStorage.setItem(CHOICE_KEY, 'classic');
+      } catch (_) {}
+    }
+    onClose();
+  }
+
+  function goNew() {
+    dismissed.current = true;
+    window.location.assign(newSiteUrl);
+  }
+
+  useEffect(() => {
+    const tick = window.setInterval(
+      () => setSecs((s) => (s > 0 ? s - 1 : 0)),
+      1000,
+    );
+    const redirect = window.setTimeout(() => {
+      if (!dismissed.current) {
+        window.location.assign(newSiteUrl);
+      }
+    }, AUTO_REDIRECT_SECONDS * 1000);
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        close(false);
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => {
+      window.clearInterval(tick);
+      window.clearTimeout(redirect);
+      document.removeEventListener('keydown', onKey);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [newSiteUrl]);
+
+  return (
+    <div
+      className={styles.backdrop}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="aw-choose-title"
+      onClick={() => close(false)}>
+      <div className={styles.card} onClick={(e) => e.stopPropagation()}>
+        <button
+          className={styles.close}
+          type="button"
+          aria-label="Close"
+          onClick={() => close(false)}>
+          ×
+        </button>
+        <span className={styles.badge}>✨ New experience</span>
+        <h2 id="aw-choose-title" className={styles.title}>
+          Azure Animations has a new home
+        </h2>
+        <p className={styles.text}>
+          Explore the new <strong>interactive animated journeys</strong>, or
+          continue on the classic site.
+        </p>
+        <div className={styles.actions}>
+          <button className={styles.primary} type="button" onClick={goNew}>
+            🚀 Explore the new site
+          </button>
+          <button
+            className={styles.secondary}
+            type="button"
+            onClick={() => close(true)}>
+            Stay on the classic site
+          </button>
+        </div>
+        <p className={styles.hint}>Taking you to the new site in {secs}s…</p>
+      </div>
+    </div>
+  );
+}
+
+export default function Root({children}: {children: React.ReactNode}) {
+  const location = useLocation();
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    let choice: string | null = null;
+    try {
+      choice = localStorage.getItem(CHOICE_KEY);
+    } catch (_) {}
+    const isHome = location.pathname === '/' || location.pathname === '';
+    setShow(isHome && choice !== 'classic');
+  }, [location.pathname]);
+
+  return (
+    <>
+      {children}
+      {show && <ChooseExperience onClose={() => setShow(false)} />}
+    </>
+  );
+}


### PR DESCRIPTION
This pull request introduces a new homepage overlay that prompts users to choose between the classic documentation site and the new interactive v2 experience. If no choice is made, users are automatically redirected to the new site after 10 seconds. The implementation includes new React logic, CSS for the modal overlay, and updates to the experience switch styles.

**New homepage experience chooser overlay:**

- Added `ChooseExperience` component in `Root.tsx` that displays a modal dialog on the homepage, prompting users to select the new v2 experience or stay on the classic site. If no selection is made, users are auto-redirected to v2 after 10 seconds. The choice to stay is persisted in `localStorage` to avoid nagging on future visits.
- Integrated the chooser overlay into the `Root` component, so it only appears on the homepage and respects the user's previous choice.

**Styling for overlay and modal:**

- Added new CSS in `Root.module.css` to style the backdrop, modal card, close button, badges, and action buttons for the experience chooser overlay, including animations and accessibility considerations.

**Experience switch UI update:**

- Replaced the old `.navbar-ai-journey` CTA styles with a new `.exp-switch` toggle design in `custom.css`, including a track and knob for an iOS-style switch, improved hover/focus states, and responsive adjustments.
- Removed legacy animated gradient and pulse effects related to the old navbar CTA, streamlining the CSS.